### PR TITLE
Fix GitHub Pages workflow artifact issue

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,8 +28,9 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+      # Explicitly use upload-pages-artifact@v1 to avoid any confusion with upload-artifact
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v1
         with:
           path: './docs'
       


### PR DESCRIPTION
This PR fixes the GitHub Pages deployment issue where the workflow was failing with 'Missing download info for actions/upload-artifact@v3'.

Changes made:
1. Downgraded from  to  to avoid any potential conflicts or confusion with 
2. Renamed the step from 'Upload artifact' to 'Upload GitHub Pages artifact' for clarity
3. Added a comment to explain the explicit version choice

This should resolve the issue by ensuring we're using a stable, well-tested version of the upload-pages-artifact action that doesn't have any dependencies on upload-artifact@v3.