### PR TITLE
Fix GitHub Pages workflow by aligning action versions with runner environment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v1
         with:
           path: './docs'
       
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR fixes the GitHub Pages deployment issue where the workflow was failing with 'Missing download info for actions/upload-artifact@v3'.

## Changes made:
1. Updated action versions to match exactly what the runner is trying to use:
   - actions/checkout@v4 (was v3)
   - actions/configure-pages@v4 (was v3)
   - actions/upload-pages-artifact@v1 (was v2)
   - actions/deploy-pages@v4 (was v2)

2. Renamed the step from 'Upload artifact' to 'Upload GitHub Pages artifact' for clarity

## Root cause analysis:
The error occurred because the workflow was attempting to use newer versions of actions than what was specified in our workflow file. The runner logs showed it was trying to use:
- actions/checkout@v4
- actions/configure-pages@v4
- actions/upload-pages-artifact@v1
- actions/deploy-pages@v4

But our workflow was using older versions. This version mismatch, particularly with upload-pages-artifact, was causing the dependency error with actions/upload-artifact@v3.

This fix ensures our workflow file explicitly specifies the exact versions that the runner is expecting to use, which should resolve the dependency issue.