### PR TITLE
Fix: Use filter.overallStatus for status filtering in ClinicalTrials

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,4 @@ jobs:
         clinical_trials_tool = ClinicalTrialsTool()
         clinical_trials_tool.cache_db_path = cache_path
         print('Clinical Trials Tool initialized successfully')
-        print('Verifying correct API parameter usage (query.recrs)...')
-        assert 'query.recrs' in open('src/tools/clinical_trials_tool.py').read()
-        print('API parameter verification successful')
         "

--- a/src/tools/clinical_trials_tool.py
+++ b/src/tools/clinical_trials_tool.py
@@ -72,9 +72,9 @@ class ClinicalTrialsTool(BaseTool):
                 "format": "json"
             }
             
-            # Add status filter if not "all"
-            if mapped_status:
-                params["query.recrs"] = mapped_status
+            # Add status filter if not 'all'
+            if status.lower() != "all" and mapped_status:
+                params["filter.overallStatus"] = mapped_status
             
             # Make the API request using the base tool's _make_request method
             data = await self._make_request(
@@ -179,4 +179,3 @@ class ClinicalTrialsTool(BaseTool):
             trials.append(trial)
         
         return trials
-    


### PR DESCRIPTION
 This PR fixes the ClinicalTrials.gov API integration by removing the unsupported query.recrs parameter and correctly using filter.overallStatus for status filtering. This resolves 400 errors and ensures compliance with the official API documentation.