### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![smithery badge](https://smithery.ai/badge/@Cicatriiz/healthcare-mcp-public)](https://smithery.ai/server/@Cicatriiz/healthcare-mcp-public)
 A Model Context Protocol (MCP) server providing AI assistants with access to healthcare data and medical information tools.
 
+<a href="https://glama.ai/mcp/servers/@Cicatriiz/healthcare-mcp-public/healthcare-mcp-public">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Cicatriiz/healthcare-mcp-public/badge" alt="Healthcare Server MCP server" />
+</a>
+
 ## Overview
 
 Healthcare MCP Server is a specialized Node.js server that implements the Model Context Protocol (MCP) to provide AI assistants with access to healthcare data and medical information tools. It enables AI models to retrieve accurate, up-to-date medical information from authoritative sources. This repository provides a single DXT package containing the complete Node.js implementation.


### PR DESCRIPTION
This PR adds a badge for the [Healthcare MCP Server](https://glama.ai/mcp/servers/@Cicatriiz/healthcare-mcp-public) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Cicatriiz/healthcare-mcp-public">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Cicatriiz/healthcare-mcp-public/badge" alt="Healthcare Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new clickable badge in the README linking to the Healthcare MCP server page on glama.ai.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->